### PR TITLE
Store PEDCalc values in an entry's CustomData area

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -4,9 +4,100 @@ using KeePassLib.Security;
 using KeePassLib.Utility;
 using PluginTools;
 using System;
+using System.Collections.Generic;
 
 namespace PEDCalc
 {
+	internal class DataMigration
+	{
+		[Flags]
+		private enum Migrations
+		{ //Update CheckAndMigrate(PwDatabase db) if changes are done here
+			None = 0,
+			Entry2CustomData = 1,
+		}
+
+		public static bool CheckAndMigrate(PwDatabase db)
+		{
+			//Do NOT create a 'ALL' flag as this will be stored as 'ALL' and by that, no additional migrations would be done
+			Migrations m = Migrations.None;
+			foreach (var v in Enum.GetValues(typeof(Migrations))) m |= (Migrations)v;
+			return CheckAndMigrate(db, m);
+		}
+
+		/// <summary>
+		/// Perform all kind of migrations between different KeePassOTP versions
+		/// </summary>
+		/// <param name="db"></param>
+		/// <returns>true if something was migrated, false if nothing was done</returns>
+		private static bool CheckAndMigrate(PwDatabase db, Migrations omFlags)
+		{
+			string sMigration = "PEDCalc.MigrationStatus";
+			bool bMigrated = false;
+
+			Migrations mStatusOld;
+			try { mStatusOld = (Migrations)Enum.Parse(typeof(Migrations), db.CustomData.Get(sMigration), true); }
+			catch { mStatusOld = Migrations.None; }
+			Migrations mStatusNew = mStatusOld;
+
+			if (MigrationRequired(Migrations.Entry2CustomData, omFlags, mStatusOld))
+			{
+				bMigrated |= MigrateEntry2CustomData(db) > 0;
+				mStatusNew |= Migrations.Entry2CustomData;
+			}
+
+			if ((mStatusNew != mStatusOld) || bMigrated)
+			{
+				db.CustomData.Set(sMigration, mStatusNew.ToString());
+				db.SettingsChanged = DateTime.UtcNow;
+				db.Modified = true;
+				KeePass.Program.MainForm.UpdateUI(false, null, false, null, false, null, KeePass.Program.MainForm.ActiveDatabase == db);
+			}
+			return bMigrated;
+		}
+
+		private static int MigrateEntry2CustomData(PwDatabase db)
+		{
+			string sDaysField = "PEDCalc.days"; //was used in previous versions which supported days only
+			int i = 0;
+			var lEntries = db.RootGroup.GetEntries(true);
+			foreach (PwEntry pe in lEntries)
+			{
+				string s = pe.Strings.ReadSafe(Configuration.Interval);
+				if (string.IsNullOrEmpty(s)) s = pe.Strings.ReadSafe(sDaysField);
+
+				if (string.IsNullOrEmpty(s)) continue;
+				
+				pe.CustomData.Set(Configuration.Interval, s);
+
+				pe.Strings.Remove(Configuration.Interval);
+				pe.Strings.Remove(sDaysField);
+
+				i++;
+			}
+
+			var lGroups = db.RootGroup.GetFlatGroupList();
+			lGroups.AddFirst(db.RootGroup);
+			foreach (PwGroup pg in lGroups)
+			{
+				string s = pg.CustomData.Get(sDaysField);
+				if (!string.IsNullOrEmpty(s))
+				{
+					pg.CustomData.Set(Configuration.Interval, s);
+					pg.CustomData.Remove(sDaysField);
+					i++;
+				}
+			}
+			return i;
+		}
+
+		private static bool MigrationRequired(Migrations mMigrate, Migrations mFlags, Migrations status)
+		{
+			if ((mMigrate & mFlags) != mMigrate) return false; //not requested
+			if ((mMigrate & status) == mMigrate) return false; //already done
+			return true;
+		}
+	}
 	internal static class EntryExtensions
 	{
 		internal static void RecalcExpiry(this PwEntry pe)
@@ -84,29 +175,29 @@ namespace PEDCalc
 
 		internal static string ReadPEDCString(this PwEntry pe)
 		{
-			if (pe.Strings.Exists(Configuration.Interval))
-				return pe.Strings.ReadSafe(Configuration.Interval);
-			return pe.Strings.ReadSafe(Configuration.DaysField);
+			return pe.CustomData.Get(Configuration.Interval);
 		}
 
 		internal static void SavePEDCString(this PwEntry pe, PEDCalcValue days)
 		{
-			pe.Strings.Remove(Configuration.DaysField);
 			if (days.Inherit)
-				pe.Strings.Remove(Configuration.Interval);
+				pe.CustomData.Remove(Configuration.Interval);
 			else
-				pe.Strings.Set(Configuration.Interval, new ProtectedString(false, days.ToString()));
+				pe.CustomData.Set(Configuration.Interval, days.ToString());
 			PEDCValueDAO.Invalidate(pe);
 		}
 
 		internal static PEDCalcValue ReadPEDCString(this ProtectedStringDictionary psd)
 		{
+			return null;
+			/*
 			string sPEDC = psd.ReadSafe(Configuration.DaysField);
 			if (string.IsNullOrEmpty(sPEDC))
 				sPEDC = psd.ReadSafe(Configuration.Interval);
 			if (!string.IsNullOrEmpty(sPEDC))
 				return PEDCalcValue.ConvertFromString(sPEDC);
 			return null;
+			*/
 		}
 	}
 
@@ -161,14 +252,11 @@ namespace PEDCalc
 
 		internal static string ReadPEDCString(this PwGroup pg)
 		{
-			if (pg.CustomData.Exists(Configuration.Interval))
-				return pg.CustomData.Get(Configuration.Interval);
-			return pg.CustomData.Get(Configuration.DaysField);
+			return pg.CustomData.Get(Configuration.Interval);
 		}
 
 		internal static void SavePEDCString(this PwGroup pg, PEDCalcValue days)
 		{
-			pg.CustomData.Remove(Configuration.DaysField);
 			if (days.Inherit)
 				pg.CustomData.Remove(Configuration.Interval);
 			else

--- a/src/PEDCalcExt.cs
+++ b/src/PEDCalcExt.cs
@@ -3,6 +3,7 @@ using KeePass.Forms;
 using KeePass.Plugins;
 using KeePass.UI;
 using KeePassLib;
+using KeePassLib.Collections;
 using KeePassLib.Security;
 using KeePassLib.Utility;
 using PluginTools;
@@ -19,7 +20,6 @@ namespace PEDCalc
 	public static class Configuration
 	{
 		private static string m_ConfigActive = "PEDCalc.active";
-		public static readonly string DaysField = "PEDCalc.days"; //was used in previous versions which supported days only
 		public static readonly string Interval = "PEDCalc.interval"; //new fieldname as meanwhile days, weeks, months and years are supported
 		public static bool Active
 		{
@@ -77,11 +77,18 @@ namespace PEDCalc
 
 			PEDCValueDAO.StartLogging();
 
+			m_host.MainWindow.FileOpened += DoMigrate;
+
 			m_host.ColumnProviderPool.Add(m_cp);
 
 			AddMenu();
 
 			return true;
+		}
+
+		private void DoMigrate(object sender, FileOpenedEventArgs e)
+		{
+			DataMigration.CheckAndMigrate(e.Database);
 		}
 
 		private void Tools_OptionsFormShown(object sender, Tools.OptionsFormsEventArgs e)
@@ -216,8 +223,10 @@ namespace PEDCalc
 			else if (m_pweForm != null)
 			{
 				PwEntry pe = m_pweForm.EntryRef;
-				m_pweForm.UpdateEntryStrings(true, true);
-				PEDCalcValue currentValue = m_pweForm.EntryStrings.ReadPEDCString();
+				StringDictionaryEx dCustomData = (StringDictionaryEx)Tools.GetField("m_sdCustomData", m_pweForm);
+				PEDCalcValue currentValue;
+				if (dCustomData != null) currentValue = PEDCalcValue.ConvertFromString(dCustomData.Get(Configuration.Interval));
+				else currentValue = PEDCalcValue.ConvertFromString(pe.ReadPEDCString());
 				if (currentValue == null) currentValue = pe.GetPEDValue(false);
 				pqaActions.SetInheritValue(pe.GetPEDValueInherit());
 				pqaActions.SetValue(currentValue);
@@ -501,12 +510,45 @@ namespace PEDCalc
 			ToolStripDropDown tsdd = (sender as PEDValue_QuickAction).DropDown;
 			if (tsdd == null) return;
 
-			m_pweForm.EntryStrings.Remove(Configuration.DaysField);
-			if (e.Value.Inherit)
-				m_pweForm.EntryStrings.Remove(Configuration.Interval);
-			else if (e.Value.unit != PEDC.SetExpired)
-				m_pweForm.EntryStrings.Set(Configuration.Interval, new ProtectedString(false, e.Value.ToString()));
-			m_pweForm.UpdateEntryStrings(false, true);
+			StringDictionaryEx dCustomData = null;
+			dCustomData = (StringDictionaryEx)Tools.GetField("m_sdCustomData", m_pweForm);
+			ListView lvCustomData = (ListView)Tools.GetControl("m_lvCustomData", m_pweForm);
+			if (dCustomData != null)
+			{
+				if (e.Value.Inherit)
+				{
+					dCustomData.Remove(Configuration.Interval);
+					if (lvCustomData != null)
+					{
+						for (int i = 0; i < lvCustomData.Items.Count; i++)
+						{
+							if (lvCustomData.Items[i].Text == Configuration.Interval)
+							{
+								lvCustomData.Items.RemoveAt(i);
+								break;
+							}
+						}
+					}
+				}
+				else if (e.Value.unit != PEDC.SetExpired)
+				{
+					dCustomData.Set(Configuration.Interval, e.Value.ToString());
+					if (lvCustomData != null)
+					{
+						for (int i = 0; i < lvCustomData.Items.Count; i++)
+						{
+							if (lvCustomData.Items[i].Text == Configuration.Interval)
+							{
+								lvCustomData.Items.RemoveAt(i);
+								break;
+							}
+						}
+						ListViewItem li = lvCustomData.Items.Add(Configuration.Interval);
+						li.SubItems.Add(Configuration.Interval);
+						li.SubItems[1].Text = e.Value.ToString();
+					}
+				}
+			}
 			if (e.Value.Off) return;
 			ExpiryControlGroup ecg = (ExpiryControlGroup)Tools.GetField("m_cgExpiry", m_pweForm);
 			PEDCalcValue pcv = e.Value;

--- a/src/PEDCalcExt.cs
+++ b/src/PEDCalcExt.cs
@@ -153,6 +153,7 @@ namespace PEDCalc
 		private ToolStripMenuItem CreatePEDMenu(bool bGroup, bool bInEntryForm)
 		{
 			ToolStripMenuItem tsmi = new ToolStripMenuItem(PluginTranslate.PluginName + "...");
+			tsmi.Name = "PEDCALC_EntryForm_ContextMenu";
 			tsmi.Image = SmallIcon;
 			tsmi.DropDownOpening += OnPEDMenuOpening;
 			PEDValue_QuickAction qa = new PEDValue_QuickAction(bGroup);
@@ -339,29 +340,39 @@ namespace PEDCalc
 		{
 			if (!Configuration.Active) return;
 			if (!(e.Form is PwEntryForm)) return;
-			m_pweForm = (PwEntryForm)e.Form;
-			m_pweForm.Shown += OnFormShown;
-			m_pweForm.FormClosed += OnFormClosed;
-			m_pweForm.EntrySaving += OnEntrySaving;
+
+			//Don't set m_pweForm now
+			//User might open an older version and m_pweForm will be overwritten by that
+			//Also other plugins might open a 2nd PwEntryForm (you never know...)
+			e.Form.Shown += OnFormShown;
 		}
 
 		private void OnFormShown(object sender, EventArgs e)
 		{
 			PwEditMode m = PwEditMode.Invalid;
+			(sender as Form).Activated -= OnFormShown;
 			PropertyInfo pEditMode = typeof(PwEntryForm).GetProperty("EditModeEx");
 			if (pEditMode != null) //will work starting with KeePass 2.41, preferred way as it's a public attribute
-				m = (PwEditMode)pEditMode.GetValue(m_pweForm, null);
+				m = (PwEditMode)pEditMode.GetValue(sender, null);
 			else // try reading private field
-				m = (PwEditMode)Tools.GetField("m_pwEditMode", m_pweForm);
+				m = (PwEditMode)Tools.GetField("m_pwEditMode", sender);
 			PluginDebug.AddSuccess("Entryform shown, editmode: " + m.ToString(), 0);
 			if ((m != PwEditMode.AddNewEntry) && (m != PwEditMode.EditExistingEntry)) return;
+			m_pweForm = sender as PwEntryForm;
+			m_pweForm.Activated += OnFormShown;
+			m_pweForm.FormClosed += OnFormClosed;
+			m_pweForm.EntrySaving += OnEntrySaving;
 			CustomContextMenuStripEx ctx = (CustomContextMenuStripEx)Tools.GetField("m_ctxDefaultTimes", m_pweForm);
 			if (ctx != null)
 			{
-				ctx.Items.Add(new ToolStripSeparator());
-				ToolStripMenuItem tsmiPED = CreatePEDMenu(false, true);
-				ctx.Items.Add(tsmiPED);
-				PluginDebug.AddSuccess("Found m_ctxDefaultTimes", 0);
+				if (ctx.Enabled && !ctx.Items.ContainsKey("PEDCALC_EntryForm_ContextMenu"))
+				{
+
+					ctx.Items.Add(new ToolStripSeparator());
+					ToolStripMenuItem tsmiPED = CreatePEDMenu(false, true);
+					ctx.Items.Add(tsmiPED);
+					PluginDebug.AddSuccess("Found m_ctxDefaultTimes", 0);
+				}
 			}
 			else
 				PluginDebug.AddError("Could not find m_ctxDefaultTimes", 0);

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -24,7 +24,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can use the default the Revision and 
 // Build Numbers by using the '*' as shown below:
-[assembly: AssemblyVersion("1.12")]
-[assembly: AssemblyFileVersion("1.12")]
+[assembly: AssemblyVersion("1.12.1")]
+[assembly: AssemblyFileVersion("1.12.1")]
 [assembly: Guid("3abc1af7-d517-4129-bbfe-d647983d48db")]
 

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration ("")]
 [assembly: AssemblyCompany ("rookiestyle")]
 [assembly: AssemblyProduct ("KeePass Plugin")]
-[assembly: AssemblyCopyright("Copyright 2020")]
+[assembly: AssemblyCopyright("Copyright 2021")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
 // This sets the default COM visibility of types in the assembly to invisible.
@@ -24,7 +24,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can use the default the Revision and 
 // Build Numbers by using the '*' as shown below:
-[assembly: AssemblyVersion("1.12.1")]
-[assembly: AssemblyFileVersion("1.12.1")]
+[assembly: AssemblyVersion("1.13")]
+[assembly: AssemblyFileVersion("1.13")]
 [assembly: Guid("3abc1af7-d517-4129-bbfe-d647983d48db")]
 

--- a/src/Utilities/Tools_Options.cs
+++ b/src/Utilities/Tools_Options.cs
@@ -147,6 +147,7 @@ namespace PluginTools
 				lv.CheckBoxes = true;
 				tpOverview.Layout += TpOverview_Layout;
 				Label lInfo = new Label();
+				lInfo.AutoSize = true;
 				lInfo.Text = "Use the checkbox to activate/deactivate debug mode";
 				lInfo.Dock = DockStyle.Bottom;
 				uc.Controls.Add(lv);
@@ -234,6 +235,7 @@ namespace PluginTools
 			llUrl.Text = PluginURL;
 			uc.Controls.Add(llUrl);
 			llUrl.Dock = DockStyle.Bottom;
+			llUrl.AutoSize = true;
 			llUrl.LinkClicked += new LinkLabelLinkClickedEventHandler(PluginURLClicked);
 		}
 

--- a/version.info
+++ b/version.info
@@ -1,5 +1,5 @@
 :
-PEDCalc - Password Expiry Calculator:1.12.1
+PEDCalc - Password Expiry Calculator:1.13
 PEDCalc - Password Expiry Calculator!de:6
 PEDCalc - Password Expiry Calculator!fr:3
 PEDCalc - Password Expiry Calculator!pt:1

--- a/version.info
+++ b/version.info
@@ -1,5 +1,5 @@
 :
-PEDCalc - Password Expiry Calculator:1.12
+PEDCalc - Password Expiry Calculator:1.12.1
 PEDCalc - Password Expiry Calculator!de:6
 PEDCalc - Password Expiry Calculator!fr:3
 PEDCalc - Password Expiry Calculator!pt:1


### PR DESCRIPTION
PEDCalc values were stored in string fields previously.
As of now, this will be stored in an entry's CustomData area and leave string fields for data entered by the user.